### PR TITLE
Add interactive endpoint tester CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,13 @@ python -m cli.main --provider google
 ```
 
 Pass `--no-open-browser` if you prefer to open consent URLs manually.
+
+### Test authenticated API endpoints
+
+After completing the OAuth flow you can explore provider APIs without leaving the terminal:
+
+```bash
+python run.py test-endpoint --provider google
+```
+
+The tester lists documented endpoints from the provider discovery catalog, injects your current access token, and shows status codes, headers, and JSON bodies. When discovery data is unavailable, you can enter custom methods and URLs.

--- a/cli/main.py
+++ b/cli/main.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Iterable, List, Tuple
+from typing import Dict, Iterable, List, Optional, Tuple
 
 import requests
 import typer
@@ -25,6 +25,8 @@ from providers.base import OAuthProvider, ProviderAction, ProviderContext
 from scopes import (
     analyze_scope_gap,
     count_methods,
+    discover_methods_for_service,
+    filter_methods_by_scopes,
     get_token_scopes,
     oauth2_userinfo_endpoints,
 )
@@ -47,6 +49,331 @@ def _prompt_file_path(prompt: str) -> Path:
         if path.exists():
             return path
         typer.echo(f"⚠️ File '{raw}' not found. Try again.")
+
+
+def _prompt_json_input(message: str, expect_object: bool = False):
+    while True:
+        raw = typer.prompt(message, default="").strip()
+        if not raw:
+            return None
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            typer.echo(f"⚠️ Invalid JSON: {exc}")
+            continue
+        if expect_object and not isinstance(data, dict):
+            typer.echo("⚠️ Please enter a JSON object (e.g. {\"foo\": \"bar\"}).")
+            continue
+        return data
+
+
+def _build_browser_opener(auto_open_browser: bool):
+    if auto_open_browser:
+        return typer.launch
+    return lambda url: typer.echo(f"Open this URL in your browser: {url}")
+
+
+def _bootstrap_session(
+    provider: OAuthProvider,
+    client_id: str,
+    client_secret: str,
+    redirect_uri: str,
+    auto_open_browser: bool,
+) -> Tuple[str, List[str]]:
+    resume = refresh_session(provider, client_id, client_secret, result_path=RESULT_PATH)
+    access_token: Optional[str] = None
+    current_scopes: List[str] = []
+
+    if resume:
+        access_token = resume["access_token"]
+        current_scopes = resume["scopes"]
+        email = resume.get("email") or "unknown"
+        typer.echo("\n🔁 Existing session detected!")
+        typer.echo(f"   • Email: {email}")
+        typer.echo(f"   • Scopes: {len(current_scopes)} scopes")
+        if typer.confirm("Use this session without opening the browser?", default=True):
+            typer.echo("\n✅ Reused existing session. Back in CLI.")
+        else:
+            access_token = None
+            current_scopes = []
+
+    if not access_token:
+        browser_opener = _build_browser_opener(auto_open_browser)
+        try:
+            _, access_token, _ = perform_oauth_flow(
+                provider,
+                client_id,
+                client_secret,
+                provider.base_scopes,
+                redirect_uri=redirect_uri,
+                browser_opener=browser_opener,
+                echo=typer.echo,
+            )
+        except OAuthResultNotFoundError as exc:
+            raise typer.Exit(str(exc))
+        except AccessTokenMissingError as exc:
+            raise typer.Exit(str(exc))
+        current_scopes = get_token_scopes(provider, access_token)
+        typer.echo("\n🎉 OAuth success. Back in CLI.")
+
+    typer.echo(f"Service: {provider.name}")
+    return access_token, current_scopes
+
+
+def _reauth_with_scopes(
+    provider: OAuthProvider,
+    client_id: str,
+    client_secret: str,
+    redirect_uri: str,
+    current_scopes: Iterable[str],
+    required_scopes: Iterable[str],
+    browser_opener,
+) -> Tuple[Optional[str], Optional[List[str]]]:
+    requested = sorted(set(current_scopes) | set(required_scopes))
+    try:
+        _, access_token, _ = perform_oauth_flow(
+            provider,
+            client_id,
+            client_secret,
+            requested,
+            redirect_uri=redirect_uri,
+            browser_opener=browser_opener,
+            echo=typer.echo,
+        )
+    except OAuthResultNotFoundError as exc:
+        typer.echo(str(exc))
+        return None, None
+    except AccessTokenMissingError as exc:
+        typer.echo(str(exc))
+        return None, None
+    new_scopes = get_token_scopes(provider, access_token)
+    typer.echo("\n✅ Re-auth complete. Updated scopes loaded.")
+    return access_token, new_scopes
+
+
+def _list_discovered_services(provider: OAuthProvider) -> List[Tuple[str, List[Dict], Dict]]:
+    services: List[Tuple[str, List[Dict], Dict]] = []
+    for service, meta in provider.discovery_metadata.items():
+        methods = discover_methods_for_service(provider, service)
+        if methods:
+            services.append((service, methods, meta))
+    return services
+
+
+def _choose_discovered_service(
+    provider: OAuthProvider,
+    current_scopes: Iterable[str],
+    services: Optional[List[Tuple[str, List[Dict], Dict]]] = None,
+) -> Optional[Tuple[str, List[Dict], Dict]]:
+    if services is None:
+        services = _list_discovered_services(provider)
+    if not services:
+        return None
+
+    typer.echo("\n📚 Discovered API services:")
+    for idx, (service, methods, _meta) in enumerate(services, start=1):
+        allowed = filter_methods_by_scopes(methods, current_scopes)
+        typer.echo(
+            f"  ({idx}) {service} — {len(allowed)}/{len(methods)} endpoints usable with current scopes"
+        )
+    typer.echo("  (0) Enter a custom URL")
+
+    choice = _prompt_choice("Select a service (0 for custom)", 0, len(services))
+    if choice == 0:
+        return None
+    return services[choice - 1]
+
+
+def _normalize_full_url(base_url: str, path: str) -> str:
+    base = base_url or ""
+    path = path or ""
+    if not base:
+        return path
+    if base.endswith("/") and path.startswith("/"):
+        return base + path[1:]
+    if not base.endswith("/") and path and not path.startswith("/"):
+        return f"{base}/{path}"
+    return f"{base}{path}"
+
+
+def _choose_discovered_method(
+    service: str, methods: List[Dict], current_scopes: Iterable[str]
+) -> Optional[Dict]:
+    filter_term = ""
+    current = set(current_scopes)
+
+    while True:
+        filtered = [
+            method
+            for method in methods
+            if not filter_term
+            or filter_term.lower() in method.get("path", "").lower()
+            or filter_term.lower() in method.get("description", "").lower()
+        ]
+
+        if not filtered:
+            typer.echo("⚠️ No endpoints matched that keyword. Try again.")
+            filter_term = typer.prompt("Keyword (blank for all)", default="").strip()
+            continue
+
+        shown = filtered[:10]
+        typer.echo(
+            f"\n🔎 {service} endpoints (showing {len(shown)} of {len(filtered)} matches)"
+        )
+        for idx, method in enumerate(shown, start=1):
+            full_url = _normalize_full_url(method.get("baseUrl", ""), method.get("path", ""))
+            missing = sorted(set(method.get("scopes", [])) - current)
+            summary = method.get("description", "").strip()
+            if summary and len(summary) > 100:
+                summary = summary[:97] + "…"
+            typer.echo(f"  ({idx}) {method.get('httpMethod', 'GET')} {full_url}")
+            if summary:
+                typer.echo(f"        {summary}")
+            if missing:
+                typer.echo(f"        Missing scopes: {', '.join(missing)}")
+
+        typer.echo("  (0) Search with a different keyword")
+        typer.echo(f"  ({len(shown) + 1}) Enter a custom endpoint")
+        choice = _prompt_choice("Pick an endpoint", 0, len(shown) + 1)
+        if choice == 0:
+            filter_term = typer.prompt("Keyword (blank for all)", default="").strip()
+            continue
+        if choice == len(shown) + 1:
+            return None
+        return shown[choice - 1]
+
+
+def _perform_endpoint_request(
+    method: str,
+    url: str,
+    access_token: str,
+    params: Optional[Dict],
+    json_body,
+):
+    headers = {"Authorization": f"Bearer {access_token}"}
+    try:
+        response = requests.request(
+            method,
+            url,
+            headers=headers,
+            params=params,
+            json=json_body,
+            timeout=30,
+        )
+    except requests.RequestException as exc:
+        typer.echo(f"❌ Request failed: {exc}")
+        return None
+
+    typer.echo(f"\nHTTP {response.status_code} {response.reason}")
+    typer.echo("Headers:")
+    for key, value in response.headers.items():
+        typer.echo(f"  {key}: {value}")
+
+    typer.echo("Body:")
+    try:
+        payload = response.json()
+    except ValueError:
+        text = response.text or "(empty body)"
+        typer.echo(text)
+    else:
+        typer.echo(json.dumps(payload, indent=2))
+
+    return response
+
+
+def _run_endpoint_tester(
+    provider: OAuthProvider,
+    client_id: str,
+    client_secret: str,
+    redirect_uri: str,
+    access_token: str,
+    current_scopes: List[str],
+    browser_opener,
+) -> Tuple[str, List[str]]:
+    typer.echo("\n🧪 API endpoint tester")
+    services = _list_discovered_services(provider)
+    if not services:
+        typer.echo("ℹ️ No discovery catalog found for this provider. Enter endpoints manually.")
+
+    while True:
+        selection = _choose_discovered_service(provider, current_scopes, services)
+        docs_url: Optional[str] = None
+        chosen_method: Optional[Dict] = None
+        required_scopes: List[str] = []
+        default_method = "GET"
+        default_url = ""
+
+        if selection:
+            service, methods, meta = selection
+            docs_url = meta.get("docs_url")
+            chosen_method = _choose_discovered_method(service, methods, current_scopes)
+            if chosen_method:
+                required_scopes = chosen_method.get("scopes", [])
+                default_method = chosen_method.get("httpMethod", "GET")
+                default_url = _normalize_full_url(
+                    chosen_method.get("baseUrl", ""), chosen_method.get("path", "")
+                )
+            else:
+                default_url = methods[0].get("baseUrl", "") if methods else ""
+        else:
+            typer.echo("\nCustom endpoint selected.")
+
+        if chosen_method is None and not default_url:
+            default_url = ""
+
+        missing_scopes = [scope for scope in required_scopes if scope not in current_scopes]
+        if missing_scopes:
+            typer.echo("\n⚠️ This endpoint requires additional scopes:")
+            for scope in missing_scopes:
+                typer.echo(f"   • {scope}")
+            if typer.confirm("Re-run consent flow to add them?", default=True):
+                result = _reauth_with_scopes(
+                    provider,
+                    client_id,
+                    client_secret,
+                    redirect_uri,
+                    current_scopes,
+                    missing_scopes,
+                    browser_opener,
+                )
+                if result[0] and result[1]:
+                    access_token, current_scopes = result  # type: ignore[assignment]
+                else:
+                    typer.echo("⚠️ Continuing with existing scopes.")
+            else:
+                typer.echo("Proceeding without requesting new scopes.")
+
+        method_default = default_method or "GET"
+        method_choice = typer.prompt("HTTP method", default=method_default).strip().upper()
+        if not method_choice:
+            method_choice = method_default.upper()
+
+        while True:
+            url_choice = typer.prompt("Request URL", default=default_url).strip()
+            if url_choice:
+                break
+            typer.echo("⚠️ URL is required.")
+
+        params = _prompt_json_input("Query parameters as JSON (blank for none)", expect_object=True)
+        body = _prompt_json_input("JSON body (blank for none)")
+
+        response = _perform_endpoint_request(
+            method_choice,
+            url_choice,
+            access_token,
+            params,
+            body,
+        )
+
+        if response is not None and response.status_code in {401, 403}:
+            typer.echo("\n⚠️ Authentication or authorization error detected.")
+            if docs_url and typer.confirm("Open the provider docs for troubleshooting?", default=True):
+                browser_opener(docs_url)
+
+        if not typer.confirm("Test another endpoint?", default=False):
+            break
+
+    return access_token, current_scopes
 
 
 def _choose_provider(provider_id: str | None) -> OAuthProvider:
@@ -171,6 +498,10 @@ def _render_menu(provider: OAuthProvider, current_scopes: List[str]) -> List[Tup
     menu.append(("snippet",))
     idx += 1
 
+    typer.echo(f"[{idx}] Test an API endpoint")
+    menu.append(("test_endpoint",))
+    idx += 1
+
     for action in provider.menu_actions():
         typer.echo(f"[{idx}] {action.label}")
         menu.append(("provider_action", action))
@@ -221,52 +552,17 @@ def _execute_wizard(
     provider: OAuthProvider = _choose_provider(provider_id)
     client_id, client_secret = _prompt_credentials(provider, redirect_uri)
 
-    resume = refresh_session(provider, client_id, client_secret, result_path=RESULT_PATH)
-    access_token: str | None = None
-    current_scopes: List[str] = []
-
-    if resume:
-        access_token = resume["access_token"]
-        current_scopes = resume["scopes"]
-        email = resume.get("email") or "unknown"
-        typer.echo("\n🔁 Existing session detected!")
-        typer.echo(f"   • Email: {email}")
-        typer.echo(f"   • Scopes: {len(current_scopes)} scopes")
-        if typer.confirm("Use this session without opening the browser?", default=True):
-            typer.echo("\n✅ Reused existing session. Back in CLI.")
-        else:
-            access_token = None
-            current_scopes = []
-
-    if not access_token:
-        opener = (lambda url: typer.echo(f"Open this URL in your browser: {url}"))
-        if auto_open_browser:
-            opener = typer.launch
-        try:
-            _, access_token, _ = perform_oauth_flow(
-                provider,
-                client_id,
-                client_secret,
-                provider.base_scopes,
-                redirect_uri=redirect_uri,
-                browser_opener=opener,
-                echo=typer.echo,
-            )
-        except OAuthResultNotFoundError as exc:
-            raise typer.Exit(str(exc))
-        except AccessTokenMissingError as exc:
-            raise typer.Exit(str(exc))
-        current_scopes = get_token_scopes(provider, access_token)
-        typer.echo("\n🎉 OAuth success. Back in CLI.")
-        typer.echo(f"Service: {provider.name}")
-    else:
-        typer.echo(f"Service: {provider.name}")
+    access_token, current_scopes = _bootstrap_session(
+        provider,
+        client_id,
+        client_secret,
+        redirect_uri,
+        auto_open_browser,
+    )
 
     _display_capabilities(provider, current_scopes)
 
-    browser_opener = (lambda url: typer.echo(f"Open this URL in your browser: {url}"))
-    if auto_open_browser:
-        browser_opener = typer.launch
+    browser_opener = _build_browser_opener(auto_open_browser)
 
     while True:
         menu = _render_menu(provider, current_scopes)
@@ -302,6 +598,18 @@ def _execute_wizard(
             typer.echo("\n🔘 Sign in with {name} — HTML snippet:\n".format(name=provider.name))
             typer.echo(snippet)
             typer.echo("\n(Use this on your site; handle the /callback on your backend.)")
+            continue
+
+        if action[0] == "test_endpoint":
+            access_token, current_scopes = _run_endpoint_tester(
+                provider,
+                client_id,
+                client_secret,
+                redirect_uri,
+                access_token,
+                current_scopes,
+                browser_opener,
+            )
             continue
 
         if action[0] == "provider_action":
@@ -356,6 +664,35 @@ def wizard(
         provider_id=provider_id,
         redirect_uri=redirect_uri,
         auto_open_browser=auto_open_browser,
+    )
+
+
+@app.command("test-endpoint")
+def test_endpoint(
+    provider_id: str = typer.Option(None, "--provider", "-p", help="Provider id to use."),
+    redirect_uri: str = typer.Option(DEFAULT_REDIRECT_URI, help="Redirect URI to register with the provider."),
+    auto_open_browser: bool = typer.Option(True, "--open-browser/--no-open-browser", help="Automatically open URLs in the browser."),
+) -> None:
+    """Obtain an access token and invoke provider APIs interactively."""
+
+    provider: OAuthProvider = _choose_provider(provider_id)
+    client_id, client_secret = _prompt_credentials(provider, redirect_uri)
+    access_token, current_scopes = _bootstrap_session(
+        provider,
+        client_id,
+        client_secret,
+        redirect_uri,
+        auto_open_browser,
+    )
+    browser_opener = _build_browser_opener(auto_open_browser)
+    _run_endpoint_tester(
+        provider,
+        client_id,
+        client_secret,
+        redirect_uri,
+        access_token,
+        current_scopes,
+        browser_opener,
     )
 
 

--- a/providers/google.py
+++ b/providers/google.py
@@ -60,10 +60,30 @@ class GoogleProvider:
             },
         }
         self.discovery_metadata = {
-            "Gmail": {"type": "google_discovery", "api": "gmail", "version": "v1"},
-            "Calendar": {"type": "google_discovery", "api": "calendar", "version": "v3"},
-            "Drive": {"type": "google_discovery", "api": "drive", "version": "v3"},
-            "Sheets": {"type": "google_discovery", "api": "sheets", "version": "v4"},
+            "Gmail": {
+                "type": "google_discovery",
+                "api": "gmail",
+                "version": "v1",
+                "docs_url": "https://developers.google.com/gmail/api/reference/rest",
+            },
+            "Calendar": {
+                "type": "google_discovery",
+                "api": "calendar",
+                "version": "v3",
+                "docs_url": "https://developers.google.com/calendar/api/v3/reference",
+            },
+            "Drive": {
+                "type": "google_discovery",
+                "api": "drive",
+                "version": "v3",
+                "docs_url": "https://developers.google.com/drive/api/v3/reference",
+            },
+            "Sheets": {
+                "type": "google_discovery",
+                "api": "sheets",
+                "version": "v4",
+                "docs_url": "https://developers.google.com/sheets/api/reference/rest",
+            },
         }
 
     # Protocol implementation -------------------------------------------------

--- a/scopes.py
+++ b/scopes.py
@@ -31,6 +31,9 @@ def _fetch_discovery_rest(api_name: str, version: str) -> Dict | None:
 
 def _extract_methods(doc: Dict) -> List[Dict]:
     methods: List[Dict] = []
+    base_url = doc.get("baseUrl") or "".join(
+        part for part in [doc.get("rootUrl", ""), doc.get("servicePath", "")] if part
+    )
 
     def walk(resources: Dict) -> None:
         if not resources:
@@ -44,6 +47,7 @@ def _extract_methods(doc: Dict) -> List[Dict]:
                             "path": method.get("path", ""),
                             "description": method.get("description", ""),
                             "scopes": method.get("scopes", []),
+                            "baseUrl": base_url,
                         }
                     )
             if "resources" in resource:


### PR DESCRIPTION
## Summary
- add an interactive API endpoint tester that reuses discovery metadata, handles missing scopes, and surfaces diagnostics
- link provider metadata to documentation and capture discovery base URLs for easier URL prefilling
- expose the tester through a Typer subcommand, wizard menu option, and README instructions

## Testing
- python run.py --help *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_68d7f1dda5a883288f9cb6d9874a6443