### PR TITLE
Add test suite and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Lint
+        run: python -m compileall .
+      - name: Run tests
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ python -m cli.main --provider google
 
 Pass `--no-open-browser` if you prefer to open consent URLs manually.
 
+## Testing
+
+Run the unit test suite with [pytest](https://docs.pytest.org/) to validate OAuth helpers, scope analysis, and CLI routing logic. Keeping these tests green helps ensure we don’t regress the interactive workflows.
+
+```bash
+pytest
+```
+
 ### Test authenticated API endpoints
 
 After completing the OAuth flow you can explore provider APIs without leaving the terminal:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 flask
 requests
 typer
+pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,131 @@
+from typer.testing import CliRunner
+
+from cli import main as cli_main
+
+
+runner = CliRunner()
+
+
+def test_cli_invokes_wizard_when_no_command(monkeypatch):
+    calls = []
+
+    def fake_execute(provider_id, redirect_uri, auto_open_browser):
+        calls.append((provider_id, redirect_uri, auto_open_browser))
+
+    monkeypatch.setattr(cli_main, "_execute_wizard", fake_execute)
+    result = runner.invoke(cli_main.app, [])
+
+    assert result.exit_code == 0
+    assert calls == [(None, cli_main.DEFAULT_REDIRECT_URI, True)]
+
+
+def test_wizard_command_routes_to_executor(monkeypatch):
+    calls = []
+
+    def fake_execute(provider_id, redirect_uri, auto_open_browser):
+        calls.append((provider_id, redirect_uri, auto_open_browser))
+
+    monkeypatch.setattr(cli_main, "_execute_wizard", fake_execute)
+    result = runner.invoke(
+        cli_main.app,
+        [
+            "wizard",
+            "--provider",
+            "google",
+            "--redirect-uri",
+            "http://localhost:9999/callback",
+            "--no-open-browser",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert calls == [("google", "http://localhost:9999/callback", False)]
+
+
+def test_sync_zapier_command_invokes_sync(monkeypatch):
+    provider = type("Provider", (), {"id": "google"})()
+
+    def fake_choose(provider_id):
+        assert provider_id == "google"
+        return provider
+
+    calls = []
+
+    def fake_sync(provider_id, dry_run, echo):
+        calls.append((provider_id, dry_run))
+
+    monkeypatch.setattr(cli_main, "_choose_provider", fake_choose)
+    monkeypatch.setattr(cli_main, "sync_provider_by_id", fake_sync)
+
+    result = runner.invoke(
+        cli_main.app,
+        [
+            "sync-zapier",
+            "--provider",
+            "google",
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert calls == [("google", True)]
+
+
+def test_test_endpoint_command_bootstraps_and_runs(monkeypatch):
+    selected_provider = object()
+
+    def fake_choose(provider_id):
+        assert provider_id is None
+        return selected_provider
+
+    def fake_prompt_credentials(provider, redirect_uri):
+        assert provider is selected_provider
+        assert redirect_uri == cli_main.DEFAULT_REDIRECT_URI
+        return "client", "secret"
+
+    def fake_bootstrap(provider, client_id, client_secret, redirect_uri, auto_open_browser):
+        assert (provider, client_id, client_secret, redirect_uri, auto_open_browser) == (
+            selected_provider,
+            "client",
+            "secret",
+            cli_main.DEFAULT_REDIRECT_URI,
+            False,
+        )
+        return "token", ["scope1"]
+
+    def fake_build_browser_opener(auto_open_browser):
+        assert auto_open_browser is False
+        return "browser-opener"
+
+    calls = []
+
+    def fake_run(provider, client_id, client_secret, redirect_uri, access_token, current_scopes, browser_opener):
+        calls.append((provider, client_id, client_secret, redirect_uri, access_token, current_scopes, browser_opener))
+        return "new-token", ["scope1"]
+
+    monkeypatch.setattr(cli_main, "_choose_provider", fake_choose)
+    monkeypatch.setattr(cli_main, "_prompt_credentials", fake_prompt_credentials)
+    monkeypatch.setattr(cli_main, "_bootstrap_session", fake_bootstrap)
+    monkeypatch.setattr(cli_main, "_build_browser_opener", fake_build_browser_opener)
+    monkeypatch.setattr(cli_main, "_run_endpoint_tester", fake_run)
+
+    result = runner.invoke(
+        cli_main.app,
+        [
+            "test-endpoint",
+            "--no-open-browser",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert calls == [
+        (
+            selected_provider,
+            "client",
+            "secret",
+            cli_main.DEFAULT_REDIRECT_URI,
+            "token",
+            ["scope1"],
+            "browser-opener",
+        )
+    ]

--- a/tests/test_oauth_flow_helpers.py
+++ b/tests/test_oauth_flow_helpers.py
@@ -1,0 +1,133 @@
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from oauth import flow
+
+
+class DummyProvider:
+    def __init__(self):
+        self.refresh_called_with = None
+        self.fetch_scopes_called_with = None
+        self.fetch_email_called_with = None
+        self.tokeninfo_endpoint = "https://example.com/tokeninfo"
+
+    def refresh_access_token(self, client_id, client_secret, refresh_token):
+        self.refresh_called_with = (client_id, client_secret, refresh_token)
+        return {
+            "access_token": "new-access-token",
+            "refresh_token": "new-refresh-token",
+        }
+
+    def fetch_token_scopes(self, access_token):
+        self.fetch_scopes_called_with = access_token
+        return ["scope.a", "scope.b"]
+
+    def fetch_user_email(self, access_token):
+        self.fetch_email_called_with = access_token
+        return "user@example.com"
+
+    def userinfo_endpoints(self):  # pragma: no cover - required by protocol
+        return []
+
+
+class NoopProvider(DummyProvider):
+    def refresh_access_token(self, *args, **kwargs):  # pragma: no cover - ensures not called
+        raise AssertionError("refresh_access_token should not be called")
+
+    def fetch_token_scopes(self, *args, **kwargs):  # pragma: no cover
+        raise AssertionError("fetch_token_scopes should not be called")
+
+    def fetch_user_email(self, *args, **kwargs):  # pragma: no cover
+        raise AssertionError("fetch_user_email should not be called")
+
+
+class StubHTTPClient:
+    def __init__(self):
+        self.calls = []
+
+    def get(self, url, headers=None, timeout=None):
+        self.calls.append({"url": url, "headers": headers, "timeout": timeout})
+        return SimpleNamespace(status_code=200, json=lambda: {"email": "user@example.com"})
+
+
+def test_safe_mask_partial_masking():
+    token = "abcdefghijklmnopqrstuvwxyz"
+    assert flow.safe_mask(token) == "abcdefghijkl…uvwxyz"
+
+
+def test_safe_mask_short_token_returns_original():
+    token = "short"
+    assert flow.safe_mask(token) == token
+
+
+def test_build_tokeninfo_url_uses_provider_endpoint():
+    provider = DummyProvider()
+    url = flow.build_tokeninfo_url(provider, "abc")
+    assert url == "https://example.com/tokeninfo?access_token=abc"
+
+
+def test_build_tokeninfo_url_without_endpoint_returns_none():
+    provider = DummyProvider()
+    provider.tokeninfo_endpoint = None
+    assert flow.build_tokeninfo_url(provider, "abc") is None
+
+
+def test_refresh_session_merges_sources_and_refreshes(tmp_path):
+    result_path = tmp_path / ".last.json"
+    result_path.write_text(json.dumps({"access_token": "old", "refresh_token": "refresh"}))
+    env_path = tmp_path / ".env"
+    env_path.write_text("ACCESS_TOKEN=env_old\nREFRESH_TOKEN=env_refresh\n")
+
+    provider = DummyProvider()
+    session = flow.refresh_session(
+        provider,
+        client_id="client",
+        client_secret="secret",
+        result_path=result_path,
+        env_path=env_path,
+    )
+
+    assert session == {
+        "access_token": "new-access-token",
+        "refresh_token": "new-refresh-token",
+        "email": "user@example.com",
+        "scopes": ["scope.a", "scope.b"],
+    }
+    # Stored tokens take precedence over env tokens.
+    assert provider.refresh_called_with == ("client", "secret", "refresh")
+    assert provider.fetch_scopes_called_with == "new-access-token"
+    assert provider.fetch_email_called_with == "new-access-token"
+    stored = json.loads(result_path.read_text())
+    assert stored["access_token"] == "new-access-token"
+    assert stored["refresh_token"] == "new-refresh-token"
+
+
+def test_refresh_session_without_tokens_returns_none(tmp_path):
+    result_path = tmp_path / ".last.json"
+    env_path = tmp_path / ".env"
+    provider = NoopProvider()
+
+    session = flow.refresh_session(
+        provider,
+        client_id="client",
+        client_secret="secret",
+        result_path=result_path,
+        env_path=env_path,
+    )
+
+    assert session is None
+
+
+def test_fetch_userinfo_invokes_http_client_with_bearer_header():
+    http_client = StubHTTPClient()
+    response = flow.fetch_userinfo(http_client, "https://example.com/userinfo", "token")
+
+    assert response.status_code == 200
+    assert http_client.calls == [
+        {
+            "url": "https://example.com/userinfo",
+            "headers": {"Authorization": "Bearer token"},
+            "timeout": 15,
+        }
+    ]

--- a/tests/test_scopes.py
+++ b/tests/test_scopes.py
@@ -1,0 +1,111 @@
+from types import SimpleNamespace
+
+import pytest
+
+import scopes
+
+
+class DummyProvider:
+    def __init__(self):
+        self.discovery_metadata = {
+            "ServiceA": {
+                "methods": [
+                    {
+                        "httpMethod": "GET",
+                        "path": "/a",
+                        "scopes": ["scope.read"],
+                    },
+                    {
+                        "httpMethod": "POST",
+                        "path": "/b",
+                        "scopes": ["scope.write"],
+                    },
+                ]
+            },
+            "ServiceB": {
+                "type": "google_discovery",
+                "api": "fake",
+                "version": "v1",
+            },
+        }
+        self.scope_groups = {
+            "ServiceA": {"read": ["scope.read"], "write": ["scope.write"]},
+            "ServiceB": {"read": ["scope.extra"], "write": []},
+        }
+
+    def userinfo_endpoints(self):  # pragma: no cover - not used here
+        return []
+
+
+@pytest.fixture(autouse=True)
+def restore_handlers():
+    original = scopes._DISCOVERY_HANDLERS.copy()
+    yield
+    scopes._DISCOVERY_HANDLERS.clear()
+    scopes._DISCOVERY_HANDLERS.update(original)
+
+
+def test_discover_methods_prefers_inline_definitions():
+    provider = DummyProvider()
+    methods = scopes.discover_methods_for_service(provider, "ServiceA")
+    assert len(methods) == 2
+    assert methods[0]["path"] == "/a"
+
+
+def test_google_discovery_handler_uses_mocked_requests(monkeypatch):
+    provider = DummyProvider()
+
+    def fake_get(url, timeout):
+        assert url.endswith("/fake/v1/rest")
+        doc = {
+            "baseUrl": "https://api.example.com/",
+            "resources": {
+                "widgets": {
+                    "methods": {
+                        "list": {
+                            "httpMethod": "GET",
+                            "path": "widgets",
+                            "description": "List widgets",
+                            "scopes": ["scope.read"],
+                        }
+                    }
+                }
+            },
+        }
+        return SimpleNamespace(status_code=200, json=lambda: doc)
+
+    monkeypatch.setattr(scopes.requests, "get", fake_get)
+    methods = scopes.discover_methods_for_service(provider, "ServiceB")
+    assert methods == [
+        {
+            "httpMethod": "GET",
+            "path": "widgets",
+            "description": "List widgets",
+            "scopes": ["scope.read"],
+            "baseUrl": "https://api.example.com/",
+        }
+    ]
+
+
+def test_filter_methods_by_scopes_allows_intersection():
+    provider = DummyProvider()
+    methods = scopes.discover_methods_for_service(provider, "ServiceA")
+    allowed = scopes.filter_methods_by_scopes(methods, ["scope.read"])
+    assert len(allowed) == 1
+    assert allowed[0]["path"] == "/a"
+
+
+def test_count_methods_returns_summary():
+    provider = DummyProvider()
+    count, preview = scopes.count_methods(provider, "ServiceA", ["scope.read", "scope.write"])
+    assert count == 2
+    assert len(preview) == 2
+
+
+def test_analyze_scope_gap_summarizes_missing_scopes():
+    provider = DummyProvider()
+    summary, missing = scopes.analyze_scope_gap(provider, ["scope.read"])
+    assert missing == ["scope.extra", "scope.write"]
+    service_a = next(item for item in summary if item["service"] == "ServiceA")
+    assert service_a["read_missing"] == []
+    assert service_a["write_missing"] == ["scope.write"]

--- a/tests/test_services_gmail.py
+++ b/tests/test_services_gmail.py
@@ -1,0 +1,84 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from providers.base import ProviderContext
+from providers.google import _handle_service_disabled
+from services.gmail import (
+    GmailServiceDisabledError,
+    list_messages,
+)
+
+
+class FakeHTTPClient:
+    def __init__(self, responses):
+        self._responses = responses
+        self.calls = []
+
+    def get(self, url, headers=None, params=None, timeout=None):
+        self.calls.append({
+            "url": url,
+            "headers": headers,
+            "params": params,
+            "timeout": timeout,
+        })
+        response = self._responses.pop(0)
+        return response
+
+
+class FakeResponse(SimpleNamespace):
+    def json(self):
+        return self.payload
+
+
+def make_disabled_response():
+    payload = {
+        "error": {
+            "status": "PERMISSION_DENIED",
+            "details": [
+                {
+                    "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+                    "reason": "SERVICE_DISABLED",
+                }
+            ],
+        }
+    }
+    return FakeResponse(status_code=403, text=json.dumps(payload), payload={})
+
+
+def test_list_messages_raises_service_disabled(monkeypatch):
+    response = make_disabled_response()
+    client = FakeHTTPClient([response])
+
+    with pytest.raises(GmailServiceDisabledError) as exc:
+        list_messages(client, "token", "123456789012-abc.apps.googleusercontent.com")
+
+    error = exc.value
+    assert error.project == "123456789012"
+    assert "gmail.googleapis.com" in error.enable_url
+
+
+def test_handle_service_disabled_prompts_and_opens_browser(monkeypatch):
+    prompts = []
+    opened = []
+    echoes = []
+
+    ctx = ProviderContext(
+        provider=None,
+        client_id="123456789012-abc.apps.googleusercontent.com",
+        client_secret="secret",
+        redirect_uri="http://localhost",
+        access_token="token",
+        http_client=None,
+        prompt=lambda message: prompts.append(message) or "",
+        confirm=lambda message: (echoes.append(message), True)[1],
+        echo=lambda message: echoes.append(message),
+        open_browser=lambda url: opened.append(url),
+    )
+
+    error = GmailServiceDisabledError("gmail.googleapis.com", ctx.client_id)
+    _handle_service_disabled(ctx, error)
+
+    assert opened == [error.enable_url]
+    assert any("enable" in message.lower() for message in echoes)


### PR DESCRIPTION
## Summary
- add pytest dependency and document how to run the test suite
- implement unit tests for OAuth helpers, scope analysis, CLI routing, and Gmail enablement guidance using mocked HTTP
- configure a GitHub Actions workflow that lints the project and runs pytest on each push and pull request

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da7d1657bc83289b0751b33739dc76