### PR TITLE
Add GitHub provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OAuth Wizard MVP - Google OAuth2
 
-🚀 Minimal MVP to validate OAuth2 Authorization Code Flow with Google.
+🚀 Minimal MVP to validate OAuth2 Authorization Code Flow with multiple SaaS providers.
 
 ## Usage
 
@@ -20,6 +20,7 @@ You can also invoke the module directly:
 
 ```bash
 python -m cli.main --provider google
+python -m cli.main --provider github
 ```
 
 Pass `--no-open-browser` if you prefer to open consent URLs manually.
@@ -38,6 +39,7 @@ After completing the OAuth flow you can explore provider APIs without leaving th
 
 ```bash
 python run.py test-endpoint --provider google
+python run.py test-endpoint --provider github
 ```
 
 The tester lists documented endpoints from the provider discovery catalog, injects your current access token, and shows status codes, headers, and JSON bodies. When discovery data is unavailable, you can enter custom methods and URLs.

--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -4,9 +4,11 @@ from typing import Dict, List
 
 from .base import EndpointInfo, OAuthProvider, ProviderAction, ProviderContext
 from .google import provider as google_provider
+from .github import provider as github_provider
 
 _PROVIDERS: Dict[str, OAuthProvider] = {
     google_provider.id: google_provider,
+    github_provider.id: github_provider,
 }
 
 

--- a/providers/github.py
+++ b/providers/github.py
@@ -1,0 +1,261 @@
+"""GitHub provider implementation for the OAuth wizard."""
+from __future__ import annotations
+
+import json
+import textwrap
+from typing import Dict, Iterable, List, Optional
+
+import requests
+
+from providers.base import EndpointInfo, ProviderAction, ProviderContext
+from services.github import (
+    GitHubRateLimitError,
+    GitHubServiceError,
+    fetch_primary_email,
+    fetch_user_profile,
+    list_repositories,
+)
+from services.zapier_sync import build_menu_action
+
+
+class GitHubProvider:
+    id = "github"
+    name = "GitHub"
+    authorize_endpoint = "https://github.com/login/oauth/authorize"
+    token_endpoint = "https://github.com/login/oauth/access_token"
+    userinfo_endpoint = "https://api.github.com/user"
+    tokeninfo_endpoint: Optional[str] = None
+
+    def __init__(self) -> None:
+        self.base_scopes = ["read:user", "user:email"]
+        self.scope_groups: Dict[str, Dict[str, List[str]]] = {
+            "Profile": {"read": ["read:user", "user:email"], "write": []},
+            "Repositories": {"read": ["public_repo"], "write": ["repo"]},
+            "Organizations": {"read": ["read:org"], "write": ["admin:org"]},
+        }
+        base_url = "https://api.github.com"
+        self.discovery_metadata = {
+            "Profile": {
+                "methods": [
+                    {
+                        "httpMethod": "GET",
+                        "path": "/user",
+                        "description": "Retrieve the authenticated user's profile.",
+                        "scopes": ["read:user"],
+                        "baseUrl": base_url,
+                    },
+                    {
+                        "httpMethod": "GET",
+                        "path": "/user/emails",
+                        "description": "List email addresses for the authenticated user.",
+                        "scopes": ["user:email"],
+                        "baseUrl": base_url,
+                    },
+                ]
+            },
+            "Repositories": {
+                "methods": [
+                    {
+                        "httpMethod": "GET",
+                        "path": "/user/repos",
+                        "description": "List repositories the user can access.",
+                        "scopes": ["public_repo"],
+                        "baseUrl": base_url,
+                    },
+                    {
+                        "httpMethod": "POST",
+                        "path": "/user/repos",
+                        "description": "Create a repository for the authenticated user.",
+                        "scopes": ["repo"],
+                        "baseUrl": base_url,
+                    },
+                ]
+            },
+        }
+
+    def build_authorization_url(self, client_id: str, redirect_uri: str, scopes: Iterable[str]) -> str:
+        scope_str = "%20".join(sorted(scopes))
+        return (
+            f"{self.authorize_endpoint}?client_id={client_id}"
+            f"&redirect_uri={redirect_uri}&scope={scope_str}&allow_signup=true"
+        )
+
+    def refresh_access_token(self, client_id: str, client_secret: str, refresh_token: str) -> Optional[Dict]:
+        return None
+
+    def fetch_token_scopes(self, access_token: str) -> List[str]:
+        try:
+            response = requests.get(
+                self.userinfo_endpoint,
+                headers={"Authorization": f"Bearer {access_token}", "Accept": "application/vnd.github+json"},
+                timeout=10,
+            )
+        except Exception:
+            return []
+        if response.status_code != 200:
+            return []
+        scopes_header = response.headers.get("X-OAuth-Scopes", "")
+        scopes = [scope.strip() for scope in scopes_header.split(",") if scope.strip()]
+        return sorted(set(scopes))
+
+    def fetch_user_email(self, access_token: str) -> Optional[str]:
+        try:
+            response = requests.get(
+                self.userinfo_endpoint,
+                headers={"Authorization": f"Bearer {access_token}", "Accept": "application/vnd.github+json"},
+                timeout=10,
+            )
+        except Exception:
+            return None
+        if response.status_code == 200:
+            data = response.json()
+            return data.get("email")
+        return None
+
+    def userinfo_endpoints(self) -> List[EndpointInfo]:
+        return [
+            EndpointInfo(
+                service="GitHub API",
+                method="GET",
+                url="https://api.github.com/user",
+                requires=["read:user"],
+                example="curl -H 'Authorization: Bearer $ACCESS_TOKEN' https://api.github.com/user",
+            ),
+        ]
+
+    def sign_in_snippet(self, client_id: str, redirect_uri: str, scopes: Iterable[str]) -> str:
+        scope_str = "%20".join(sorted(scopes))
+        href = (
+            f"{self.authorize_endpoint}?client_id={client_id}"
+            f"&redirect_uri={redirect_uri}&scope={scope_str}&allow_signup=true"
+        )
+        template = textwrap.dedent(
+            """<a href="{href}">
+  <img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" alt="Sign in with GitHub" style="height:40px;">
+</a>"""
+        )
+        return template.format(href=href)
+
+    def menu_actions(self) -> List[ProviderAction]:
+        def _handle_error(ctx: ProviderContext, exc: GitHubServiceError) -> None:
+            if isinstance(exc, GitHubRateLimitError):
+                ctx.echo(str(exc))
+                return
+            ctx.echo(f"⚠️ {exc}")
+
+        def _http_client(ctx: ProviderContext):
+            return ctx.http_client or requests
+
+        def show_profile(ctx: ProviderContext) -> None:
+            try:
+                profile = fetch_user_profile(_http_client(ctx), ctx.access_token)
+            except GitHubServiceError as exc:
+                _handle_error(ctx, exc)
+                return
+            ctx.echo(json.dumps(profile, indent=2))
+
+        def show_email(ctx: ProviderContext) -> None:
+            try:
+                email = fetch_primary_email(_http_client(ctx), ctx.access_token)
+            except GitHubServiceError as exc:
+                _handle_error(ctx, exc)
+                return
+            if email:
+                ctx.echo(f"📧 Primary email: {email}")
+            else:
+                ctx.echo("ℹ️ No primary email returned (scope missing or not set).")
+
+        def show_repositories(ctx: ProviderContext) -> None:
+            try:
+                repos = list_repositories(_http_client(ctx), ctx.access_token)
+            except GitHubServiceError as exc:
+                _handle_error(ctx, exc)
+                return
+            if not repos:
+                ctx.echo("ℹ️ No repositories returned.")
+                return
+            ctx.echo("\n📂 Recent repositories:")
+            for repo in repos:
+                visibility = "private" if repo["private"] else "public"
+                line = f"- {repo['name']} ({visibility})"
+                if repo["html_url"]:
+                    line += f" → {repo['html_url']}"
+                ctx.echo(line)
+                if repo["description"]:
+                    ctx.echo(f"    {repo['description']}")
+
+        actions = [
+            ProviderAction(
+                key="github_profile",
+                label="GitHub: show user profile JSON",
+                handler=show_profile,
+                requires_any_scopes=["read:user"],
+            ),
+            ProviderAction(
+                key="github_email",
+                label="GitHub: show primary email",
+                handler=show_email,
+                requires_any_scopes=["user:email"],
+                missing_scope_message="⚠️ GitHub email scope missing. Add 'user:email' and re-auth.",
+            ),
+            ProviderAction(
+                key="github_repos",
+                label="GitHub: list recent repositories",
+                handler=show_repositories,
+                requires_any_scopes=["repo", "public_repo"],
+                missing_scope_message="⚠️ GitHub repo scope missing. Add 'repo' or 'public_repo' and re-auth.",
+            ),
+        ]
+
+        zapier_action = build_menu_action(self.id)
+        if zapier_action:
+            actions.append(zapier_action)
+
+        return actions
+
+    def welcome_text(self, redirect_uri: str) -> str:
+        return textwrap.dedent(
+            """
+            👋 Welcome to the GitHub OAuth wizard!
+            If you already generated credentials in GitHub Developer Settings, choose option (1) to upload them.
+            Otherwise select option (3) and we'll walk you through creating an OAuth app.
+            """
+        ).strip()
+
+    def manual_entry_instructions(self) -> str:
+        return textwrap.dedent(
+            """
+            ✍️ Paste your GitHub OAuth app credentials below.
+            Manage your apps at: https://github.com/settings/developers
+            """
+        ).strip()
+
+    def app_creation_instructions(self, redirect_uri: str) -> str:
+        return textwrap.dedent(
+            f"""
+            🛠️ Create a new OAuth app at https://github.com/settings/applications/new
+            Recommended values:
+            • Application name: OAuth Wizard Demo
+            • Homepage URL: https://example.com
+            • Authorization callback URL: {redirect_uri}
+            After creation, copy the Client ID and generate a new Client Secret.
+            """
+        ).strip()
+
+    def load_credentials_from_file(self, path: str) -> tuple[str, str]:
+        with open(path) as fh:
+            data = json.load(fh)
+        client_id = data.get("client_id")
+        client_secret = data.get("client_secret")
+        if not client_id or not client_secret:
+            raise ValueError("GitHub JSON must contain 'client_id' and 'client_secret'.")
+        return client_id, client_secret
+
+    def validate_client_id(self, client_id: str) -> bool:
+        return bool(client_id) and len(client_id) == 20
+
+    def validate_client_secret(self, client_secret: str) -> bool:
+        return bool(client_secret) and len(client_secret) >= 35
+
+
+provider = GitHubProvider()

--- a/services/github.py
+++ b/services/github.py
@@ -1,0 +1,115 @@
+"""Helpers for interacting with GitHub APIs via the OAuth wizard."""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+API_BASE = "https://api.github.com"
+ACCEPT_HEADER = "application/vnd.github+json"
+
+
+class GitHubServiceError(RuntimeError):
+    """Base exception raised for GitHub API errors."""
+
+    def __init__(self, message: str, *, response: Any | None = None) -> None:
+        super().__init__(message)
+        self.response = response
+
+
+class GitHubRateLimitError(GitHubServiceError):
+    """Raised when the GitHub API rate limit has been exhausted."""
+
+    def __init__(self, reset: Optional[str], *, response: Any | None = None) -> None:
+        message = "GitHub API rate limit exceeded."
+        if reset:
+            message += f" Resets at {reset}."
+        super().__init__(message, response=response)
+        self.reset = reset
+
+
+def _headers(access_token: str) -> Dict[str, str]:
+    return {
+        "Authorization": f"Bearer {access_token}",
+        "Accept": ACCEPT_HEADER,
+    }
+
+
+def _raise_for_error(response) -> None:
+    if response.status_code == 403 and response.headers.get("X-RateLimit-Remaining") == "0":
+        raise GitHubRateLimitError(response.headers.get("X-RateLimit-Reset"), response=response)
+    raise GitHubServiceError(
+        f"GitHub API error: {response.status_code} {response.text}", response=response
+    )
+
+
+def list_repositories(
+    http_client,
+    access_token: str,
+    *,
+    visibility: str = "all",
+    per_page: int = 5,
+) -> List[Dict[str, Any]]:
+    """Return a summary of the authenticated user's repositories."""
+
+    params = {
+        "visibility": visibility,
+        "affiliation": "owner,collaborator,organization_member",
+        "sort": "updated",
+        "direction": "desc",
+        "per_page": per_page,
+    }
+    response = http_client.get(
+        f"{API_BASE}/user/repos",
+        headers=_headers(access_token),
+        params=params,
+        timeout=20,
+    )
+    if response.status_code != 200:
+        _raise_for_error(response)
+
+    data = response.json()
+    repos: List[Dict[str, Any]] = []
+    for item in data:
+        repos.append(
+            {
+                "name": item.get("full_name") or item.get("name"),
+                "private": bool(item.get("private")),
+                "html_url": item.get("html_url", ""),
+                "description": item.get("description") or "",
+            }
+        )
+    return repos
+
+
+def fetch_primary_email(http_client, access_token: str) -> Optional[str]:
+    """Return the primary email address for the authenticated user."""
+
+    response = http_client.get(
+        f"{API_BASE}/user/emails",
+        headers=_headers(access_token),
+        timeout=20,
+    )
+    if response.status_code != 200:
+        _raise_for_error(response)
+
+    emails = response.json()
+    if not isinstance(emails, list):
+        return None
+    primary = next((item for item in emails if item.get("primary")), None)
+    if primary:
+        return primary.get("email")
+    if emails:
+        return emails[0].get("email")
+    return None
+
+
+def fetch_user_profile(http_client, access_token: str) -> Dict[str, Any]:
+    """Return the authenticated user's profile information."""
+
+    response = http_client.get(
+        f"{API_BASE}/user",
+        headers=_headers(access_token),
+        timeout=20,
+    )
+    if response.status_code != 200:
+        _raise_for_error(response)
+    return response.json()

--- a/tests/test_providers_github.py
+++ b/tests/test_providers_github.py
@@ -1,0 +1,101 @@
+from types import SimpleNamespace
+
+import providers.github as github_module
+
+from providers.github import GitHubProvider
+
+
+def test_build_authorization_url_encodes_values():
+    provider = GitHubProvider()
+    url = provider.build_authorization_url("abc", "http://localhost:8000/callback", ["read:user", "user:email"])
+    assert "client_id=abc" in url
+    assert "redirect_uri=http://localhost:8000/callback" in url
+    assert "scope=read:user%20user:email" in url
+    assert url.endswith("allow_signup=true")
+
+
+def test_fetch_token_scopes_reads_header(monkeypatch):
+    provider = GitHubProvider()
+
+    def fake_get(url, headers, timeout):
+        return SimpleNamespace(status_code=200, headers={"X-OAuth-Scopes": "repo, user:email"})
+
+    monkeypatch.setattr("providers.github.requests.get", fake_get)
+    scopes = provider.fetch_token_scopes("token")
+    assert scopes == ["repo", "user:email"]
+
+
+def test_fetch_user_email_returns_value(monkeypatch):
+    provider = GitHubProvider()
+
+    def fake_get(url, headers, timeout):
+        return SimpleNamespace(status_code=200, json=lambda: {"email": "octocat@example.com"})
+
+    monkeypatch.setattr("providers.github.requests.get", fake_get)
+    email = provider.fetch_user_email("token")
+    assert email == "octocat@example.com"
+
+
+def test_sign_in_snippet_mentions_github():
+    provider = GitHubProvider()
+    snippet = provider.sign_in_snippet("abc", "http://localhost/callback", ["read:user"])
+    assert "Sign in with GitHub" in snippet
+    assert "client_id=abc" in snippet
+
+
+def test_menu_action_invokes_repository_listing(monkeypatch, capsys):
+    provider = GitHubProvider()
+
+    action = next(a for a in provider.menu_actions() if a.key == "github_repos")
+
+    def fake_list(http_client, access_token):
+        return [
+            {"name": "octocat/Hello-World", "private": False, "html_url": "", "description": ""}
+        ]
+
+    monkeypatch.setattr("providers.github.list_repositories", fake_list)
+
+    context = SimpleNamespace(
+        provider=provider,
+        client_id="id",
+        client_secret="secret",
+        redirect_uri="http://localhost/callback",
+        access_token="token",
+        http_client=None,
+        prompt=lambda message: "",
+        confirm=lambda message: True,
+        echo=lambda message: print(message),
+        open_browser=lambda url: None,
+    )
+
+    action.handler(context)
+    captured = capsys.readouterr()
+    assert "octocat/Hello-World" in captured.out
+
+
+def test_menu_action_handles_rate_limit(monkeypatch, capsys):
+    provider = GitHubProvider()
+
+    action = next(a for a in provider.menu_actions() if a.key == "github_repos")
+
+    def fake_list(http_client, access_token):
+        raise github_module.GitHubRateLimitError("1700000000")
+
+    monkeypatch.setattr("providers.github.list_repositories", fake_list)
+
+    context = SimpleNamespace(
+        provider=provider,
+        client_id="id",
+        client_secret="secret",
+        redirect_uri="http://localhost/callback",
+        access_token="token",
+        http_client=None,
+        prompt=lambda message: "",
+        confirm=lambda message: True,
+        echo=lambda message: print(message),
+        open_browser=lambda url: None,
+    )
+
+    action.handler(context)
+    captured = capsys.readouterr()
+    assert "rate limit" in captured.out.lower()

--- a/tests/test_services_github.py
+++ b/tests/test_services_github.py
@@ -1,0 +1,124 @@
+import pytest
+from types import SimpleNamespace
+
+from services.github import (
+    GitHubRateLimitError,
+    GitHubServiceError,
+    fetch_primary_email,
+    fetch_user_profile,
+    list_repositories,
+)
+
+
+def _fake_response(status_code=200, json_data=None, headers=None, text=""):
+    if json_data is None:
+        json_data = {}
+    if headers is None:
+        headers = {}
+    return SimpleNamespace(
+        status_code=status_code,
+        json=lambda: json_data,
+        headers=headers,
+        text=text,
+    )
+
+
+def test_list_repositories_returns_summary():
+    responses = [
+        _fake_response(
+            json_data=[
+                {
+                    "full_name": "octocat/Hello-World",
+                    "private": False,
+                    "html_url": "https://github.com/octocat/Hello-World",
+                    "description": "A friendly repository",
+                },
+                {
+                    "name": "private-repo",
+                    "private": True,
+                    "html_url": "https://github.com/octocat/private-repo",
+                    "description": None,
+                },
+            ]
+        )
+    ]
+
+    def fake_get(url, headers, params, timeout):
+        assert url.endswith("/user/repos")
+        assert params["per_page"] == 5
+        return responses.pop(0)
+
+    http_client = SimpleNamespace(get=fake_get)
+
+    repos = list_repositories(http_client, "token")
+
+    assert repos == [
+        {
+            "name": "octocat/Hello-World",
+            "private": False,
+            "html_url": "https://github.com/octocat/Hello-World",
+            "description": "A friendly repository",
+        },
+        {
+            "name": "private-repo",
+            "private": True,
+            "html_url": "https://github.com/octocat/private-repo",
+            "description": "",
+        },
+    ]
+
+
+def test_list_repositories_raises_on_error():
+    response = _fake_response(status_code=500, text="boom")
+
+    def fake_get(url, headers, params, timeout):
+        return response
+
+    http_client = SimpleNamespace(get=fake_get)
+
+    with pytest.raises(GitHubServiceError):
+        list_repositories(http_client, "token")
+
+
+def test_fetch_primary_email_prefers_primary_entry():
+    response = _fake_response(
+        json_data=[
+            {"email": "secondary@example.com", "primary": False},
+            {"email": "primary@example.com", "primary": True},
+        ]
+    )
+
+    def fake_get(url, headers, timeout):
+        return response
+
+    http_client = SimpleNamespace(get=fake_get)
+    email = fetch_primary_email(http_client, "token")
+    assert email == "primary@example.com"
+
+
+def test_fetch_primary_email_handles_rate_limit():
+    response = _fake_response(
+        status_code=403,
+        headers={"X-RateLimit-Remaining": "0", "X-RateLimit-Reset": "1700000000"},
+        text="rate limited",
+    )
+
+    def fake_get(url, headers, timeout):
+        return response
+
+    http_client = SimpleNamespace(get=fake_get)
+
+    with pytest.raises(GitHubRateLimitError):
+        fetch_primary_email(http_client, "token")
+
+
+def test_fetch_user_profile_returns_payload():
+    payload = {"login": "octocat"}
+    response = _fake_response(json_data=payload)
+
+    def fake_get(url, headers, timeout):
+        return response
+
+    http_client = SimpleNamespace(get=fake_get)
+    profile = fetch_user_profile(http_client, "token")
+    assert profile == payload


### PR DESCRIPTION
## Summary
- add a GitHub OAuth provider implementation with menu actions and discovery metadata
- introduce GitHub service helpers for profile, email, and repository inspection
- update the CLI registry, documentation, and tests to cover the new provider

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6980a4f8083289cb9c682ea10d8fe