### PR TITLE
Add Basecamp, Slack, Trello, and Notion providers

### DIFF
--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -5,10 +5,18 @@ from typing import Dict, List
 from .base import EndpointInfo, OAuthProvider, ProviderAction, ProviderContext
 from .google import provider as google_provider
 from .github import provider as github_provider
+from .basecamp import provider as basecamp_provider
+from .slack import provider as slack_provider
+from .trello import provider as trello_provider
+from .notion import provider as notion_provider
 
 _PROVIDERS: Dict[str, OAuthProvider] = {
     google_provider.id: google_provider,
     github_provider.id: github_provider,
+    basecamp_provider.id: basecamp_provider,
+    slack_provider.id: slack_provider,
+    trello_provider.id: trello_provider,
+    notion_provider.id: notion_provider,
 }
 
 

--- a/providers/basecamp.py
+++ b/providers/basecamp.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+import json
+import re
+import textwrap
+from typing import Dict, Iterable, List, Optional
+
+import requests
+
+from providers.base import EndpointInfo, ProviderAction, ProviderContext
+
+
+_USER_AGENT = "OAuth Wizard CLI (support@example.com)"
+
+
+def _authorization_headers(token: str) -> Dict[str, str]:
+    return {
+        "Authorization": f"Bearer {token}",
+        "User-Agent": _USER_AGENT,
+    }
+
+
+class BasecampProvider:
+    id = "basecamp"
+    name = "Basecamp"
+    authorize_endpoint = "https://launchpad.37signals.com/authorization/new"
+    token_endpoint = "https://launchpad.37signals.com/authorization/token"
+    userinfo_endpoint = "https://launchpad.37signals.com/authorization.json"
+    tokeninfo_endpoint: Optional[str] = None
+    token_request_headers: Dict[str, str] = {
+        "Content-Type": "application/x-www-form-urlencoded",
+    }
+
+    def __init__(self) -> None:
+        self.base_scopes = ["openid", "profile", "email"]
+        self.scope_groups: Dict[str, Dict[str, List[str]]] = {
+            "Identity": {"read": ["openid", "profile", "email"], "write": []},
+            "Offline access": {"read": [], "write": ["offline_access"]},
+            "Projects": {
+                "read": ["projects:read"],
+                "write": ["projects:write"],
+            },
+        }
+        self.discovery_metadata = {
+            "Identity": {
+                "type": "basecamp_catalog",
+                "base_url": "https://launchpad.37signals.com",
+                "method_map": [
+                    {
+                        "path": "/authorization.json",
+                        "httpMethod": "GET",
+                        "description": "Retrieve the authorized accounts and identity profile.",
+                        "scopes": ["openid", "profile", "email"],
+                    }
+                ],
+                "docs_url": "https://github.com/basecamp/api/blob/master/sections/authentication.md",
+            },
+            "Projects": {
+                "type": "basecamp_catalog",
+                "base_url": "https://3.basecampapi.com",
+                "method_map": [
+                    {
+                        "path": "/{account_id}/projects.json",
+                        "httpMethod": "GET",
+                        "description": "List projects for the first connected Basecamp account.",
+                        "scopes": ["projects:read"],
+                    },
+                    {
+                        "path": "/{account_id}/people.json",
+                        "httpMethod": "GET",
+                        "description": "List people in the Basecamp account.",
+                        "scopes": ["projects:read"],
+                    },
+                    {
+                        "path": "/{account_id}/buckets/{project_id}/todosets.json",
+                        "httpMethod": "GET",
+                        "description": "Inspect todo sets inside a project bucket.",
+                        "scopes": ["projects:write"],
+                    },
+                ],
+                "docs_url": "https://github.com/basecamp/bc3-api",
+            },
+        }
+
+    # Protocol implementation -------------------------------------------------
+    def build_authorization_url(
+        self, client_id: str, redirect_uri: str, scopes: Iterable[str]
+    ) -> str:
+        scope_str = "%20".join(sorted(scopes))
+        return (
+            f"{self.authorize_endpoint}?type=web_server"
+            f"&client_id={client_id}"
+            f"&redirect_uri={redirect_uri}"
+            f"&response_type=code"
+            f"&scope={scope_str}"
+        )
+
+    def refresh_access_token(
+        self, client_id: str, client_secret: str, refresh_token: str
+    ) -> Optional[Dict]:
+        try:
+            response = requests.post(
+                self.token_endpoint,
+                data={
+                    "type": "refresh",
+                    "client_id": client_id,
+                    "redirect_uri": "oob",
+                    "client_secret": client_secret,
+                    "refresh_token": refresh_token,
+                    "grant_type": "refresh_token",
+                },
+                headers=self.token_request_headers,
+                timeout=15,
+            )
+        except Exception:
+            return None
+        if response.status_code == 200:
+            return response.json()
+        return None
+
+    def fetch_token_scopes(self, access_token: str) -> List[str]:
+        try:
+            response = requests.get(
+                self.userinfo_endpoint,
+                headers=_authorization_headers(access_token),
+                timeout=10,
+            )
+        except Exception:
+            return []
+        if response.status_code != 200:
+            return []
+        data = response.json()
+        scopes = data.get("scopes") or []
+        if isinstance(scopes, str):
+            scopes = [scope.strip() for scope in scopes.split() if scope.strip()]
+        return sorted(set(scopes))
+
+    def fetch_user_email(self, access_token: str) -> Optional[str]:
+        try:
+            response = requests.get(
+                self.userinfo_endpoint,
+                headers=_authorization_headers(access_token),
+                timeout=10,
+            )
+        except Exception:
+            return None
+        if response.status_code != 200:
+            return None
+        data = response.json()
+        identity = data.get("identity") or {}
+        return identity.get("email_address")
+
+    def userinfo_endpoints(self) -> List[EndpointInfo]:
+        return [
+            EndpointInfo(
+                service="Basecamp Authorization",
+                method="GET",
+                url="https://launchpad.37signals.com/authorization.json",
+                requires=["openid", "profile", "email"],
+                example=(
+                    "curl -H 'Authorization: Bearer $ACCESS_TOKEN' "
+                    "https://launchpad.37signals.com/authorization.json"
+                ),
+            )
+        ]
+
+    def sign_in_snippet(
+        self, client_id: str, redirect_uri: str, scopes: Iterable[str]
+    ) -> str:
+        scope_str = "%20".join(sorted(scopes))
+        return textwrap.dedent(
+            """
+            <a href="{href}">
+              <button style="padding:10px 16px;background:#2e5bff;color:#fff;border:none;border-radius:4px;">
+                Sign in with Basecamp
+              </button>
+            </a>
+            """
+        ).strip().format(
+            href=(
+                f"{self.authorize_endpoint}?type=web_server&client_id={client_id}"
+                f"&redirect_uri={redirect_uri}&response_type=code&scope={scope_str}"
+            )
+        )
+
+    def menu_actions(self) -> List[ProviderAction]:
+        def _http(ctx: ProviderContext):
+            return ctx.http_client or requests
+
+        def show_accounts(ctx: ProviderContext) -> None:
+            http = _http(ctx)
+            response = http.get(
+                self.userinfo_endpoint,
+                headers=_authorization_headers(ctx.access_token),
+                timeout=10,
+            )
+            if response.status_code != 200:
+                ctx.echo(f"⚠️ Failed to load accounts: {response.status_code} {response.text}")
+                return
+            data = response.json()
+            accounts = data.get("accounts", [])
+            if not accounts:
+                ctx.echo("ℹ️ No Basecamp accounts returned for this token.")
+                return
+            ctx.echo("\n🏢 Connected Basecamp accounts:")
+            for account in accounts:
+                ctx.echo(f"  • {account.get('name')} (id={account.get('id')})")
+
+        def list_projects(ctx: ProviderContext) -> None:
+            http = _http(ctx)
+            response = http.get(
+                self.userinfo_endpoint,
+                headers=_authorization_headers(ctx.access_token),
+                timeout=10,
+            )
+            if response.status_code != 200:
+                ctx.echo("⚠️ Unable to determine account information for projects.")
+                return
+            data = response.json()
+            accounts = data.get("accounts") or []
+            if not accounts:
+                ctx.echo("ℹ️ No accounts available to list projects from.")
+                return
+            account_id = accounts[0].get("id")
+            if not account_id:
+                ctx.echo("⚠️ Account identifier missing in response.")
+                return
+            url = f"https://3.basecampapi.com/{account_id}/projects.json"
+            response = http.get(
+                url,
+                headers={**_authorization_headers(ctx.access_token), "Accept": "application/json"},
+                timeout=10,
+            )
+            if response.status_code != 200:
+                ctx.echo(f"⚠️ Could not list projects: {response.status_code} {response.text}")
+                return
+            projects = response.json()
+            if not projects:
+                ctx.echo("ℹ️ No projects returned.")
+                return
+            ctx.echo("\n📋 Recent projects:")
+            for project in projects[:5]:
+                ctx.echo(f"  • {project.get('name')} → {project.get('app_url')}")
+
+        return [
+            ProviderAction(
+                key="basecamp_accounts",
+                label="Basecamp: list connected accounts",
+                handler=show_accounts,
+                requires_any_scopes=["openid", "profile"],
+                missing_scope_message="⚠️ Identity scopes missing. Re-auth with openid/profile/email.",
+            ),
+            ProviderAction(
+                key="basecamp_projects",
+                label="Basecamp: list first account projects",
+                handler=list_projects,
+                requires_any_scopes=["projects:read", "offline_access"],
+                missing_scope_message="⚠️ Add 'projects:read' (and optionally offline_access) to browse projects.",
+            ),
+        ]
+
+    def welcome_text(self, redirect_uri: str) -> str:
+        return textwrap.dedent(
+            """
+            👋 Welcome to the Basecamp OAuth wizard!
+            Upload an existing Launchpad client file or let us guide you to the Basecamp developer console.
+            """
+        ).strip()
+
+    def manual_entry_instructions(self) -> str:
+        return textwrap.dedent(
+            """
+            ✍️ Paste the Client ID and Secret from your Basecamp Launchpad application.
+            Manage credentials at https://integrate.37signals.com/apps.
+            """
+        ).strip()
+
+    def app_creation_instructions(self, redirect_uri: str) -> str:
+        return textwrap.dedent(
+            f"""
+            🛠️ Create a new OAuth application at https://integrate.37signals.com/apps.
+            Recommended values:
+            • Redirect URI: {redirect_uri}
+            • Default scopes: openid profile email offline_access projects:read
+            After saving, copy the Client ID and Secret so we can finish the flow.
+            """
+        ).strip()
+
+    def load_credentials_from_file(self, path: str) -> tuple[str, str]:
+        with open(path) as fh:
+            data = json.load(fh)
+        client_id = data.get("client_id") or data.get("app_id")
+        client_secret = data.get("client_secret") or data.get("secret")
+        if not client_id or not client_secret:
+            raise ValueError(
+                "Basecamp client JSON must include 'client_id' and 'client_secret'."
+            )
+        return client_id, client_secret
+
+    def validate_client_id(self, client_id: str) -> bool:
+        return bool(re.fullmatch(r"[0-9a-f]{32}", client_id))
+
+    def validate_client_secret(self, client_secret: str) -> bool:
+        return bool(client_secret) and len(client_secret) >= 32
+
+
+provider = BasecampProvider()

--- a/providers/notion.py
+++ b/providers/notion.py
@@ -1,0 +1,321 @@
+from __future__ import annotations
+
+import base64
+import json
+import re
+import textwrap
+from typing import Dict, Iterable, List, Optional
+
+import requests
+
+from providers.base import EndpointInfo, ProviderAction, ProviderContext
+
+
+NOTION_VERSION = "2022-06-28"
+
+
+def _notion_headers(token: str, *, content_type: Optional[str] = None) -> Dict[str, str]:
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Notion-Version": NOTION_VERSION,
+    }
+    if content_type:
+        headers["Content-Type"] = content_type
+    return headers
+
+
+class NotionProvider:
+    id = "notion"
+    name = "Notion"
+    authorize_endpoint = "https://api.notion.com/v1/oauth/authorize"
+    token_endpoint = "https://api.notion.com/v1/oauth/token"
+    userinfo_endpoint = "https://api.notion.com/v1/users/me"
+    tokeninfo_endpoint: Optional[str] = None
+    token_request_headers: Dict[str, str] = {}
+
+    def __init__(self) -> None:
+        self.base_scopes = ["read:content"]
+        self.scope_groups: Dict[str, Dict[str, List[str]]] = {
+            "Content": {
+                "read": ["read:content", "databases:read"],
+                "write": ["update:content", "insert:content", "delete:content"],
+            },
+            "Users": {"read": ["read:user"], "write": ["write:user"]},
+            "Comments": {"read": ["read:comment"], "write": ["write:comment"]},
+        }
+        self.discovery_metadata = {
+            "Content": {
+                "type": "notion_catalog",
+                "base_url": "https://api.notion.com/v1",
+                "method_map": [
+                    {
+                        "path": "/search",
+                        "httpMethod": "POST",
+                        "description": "Search pages and databases accessible to the integration.",
+                        "scopes": ["read:content"],
+                    },
+                    {
+                        "path": "/databases",
+                        "httpMethod": "GET",
+                        "description": "List databases shared with the integration.",
+                        "scopes": ["databases:read"],
+                    },
+                    {
+                        "path": "/pages",
+                        "httpMethod": "POST",
+                        "description": "Create a new page.",
+                        "scopes": ["insert:content"],
+                    },
+                ],
+                "docs_url": "https://developers.notion.com/reference/intro",
+            },
+            "Users": {
+                "type": "notion_catalog",
+                "base_url": "https://api.notion.com/v1",
+                "method_map": [
+                    {
+                        "path": "/users",
+                        "httpMethod": "GET",
+                        "description": "List users in the workspace.",
+                        "scopes": ["read:user"],
+                    },
+                    {
+                        "path": "/users/{user_id}",
+                        "httpMethod": "GET",
+                        "description": "Retrieve a user's details.",
+                        "scopes": ["read:user"],
+                    },
+                ],
+                "docs_url": "https://developers.notion.com/reference/get-users",
+            },
+            "Comments": {
+                "type": "notion_catalog",
+                "base_url": "https://api.notion.com/v1",
+                "method_map": [
+                    {
+                        "path": "/comments",
+                        "httpMethod": "POST",
+                        "description": "Create a comment on a page or block.",
+                        "scopes": ["write:comment"],
+                    },
+                    {
+                        "path": "/comments",
+                        "httpMethod": "GET",
+                        "description": "List comments for a block.",
+                        "scopes": ["read:comment"],
+                    },
+                ],
+                "docs_url": "https://developers.notion.com/reference/post-comment",
+            },
+        }
+
+    # Protocol implementation -------------------------------------------------
+    def build_authorization_url(
+        self, client_id: str, redirect_uri: str, scopes: Iterable[str]
+    ) -> str:
+        scope_str = "%20".join(sorted(scopes))
+        return (
+            f"{self.authorize_endpoint}?client_id={client_id}"
+            f"&redirect_uri={redirect_uri}&response_type=code&owner=user&scope={scope_str}"
+        )
+
+    def refresh_access_token(
+        self, client_id: str, client_secret: str, refresh_token: str
+    ) -> Optional[Dict]:
+        basic = base64.b64encode(f"{client_id}:{client_secret}".encode()).decode()
+        headers = {
+            "Authorization": f"Basic {basic}",
+            "Content-Type": "application/json",
+        }
+        try:
+            response = requests.post(
+                self.token_endpoint,
+                headers=headers,
+                json={"grant_type": "refresh_token", "refresh_token": refresh_token},
+                timeout=15,
+            )
+        except Exception:
+            return None
+        if response.status_code == 200:
+            return response.json()
+        return None
+
+    def fetch_token_scopes(self, access_token: str) -> List[str]:
+        # Notion does not expose an introspection endpoint; rely on granted scopes.
+        return []
+
+    def fetch_user_email(self, access_token: str) -> Optional[str]:
+        try:
+            response = requests.get(
+                self.userinfo_endpoint,
+                headers=_notion_headers(access_token),
+                timeout=10,
+            )
+        except Exception:
+            return None
+        if response.status_code != 200:
+            return None
+        data = response.json()
+        person = (data.get("person") or {}) if isinstance(data, dict) else {}
+        return person.get("email")
+
+    def userinfo_endpoints(self) -> List[EndpointInfo]:
+        return [
+            EndpointInfo(
+                service="Notion API",
+                method="GET",
+                url="https://api.notion.com/v1/users/me",
+                requires=["read:user"],
+                example=(
+                    "curl -H 'Authorization: Bearer $ACCESS_TOKEN' "
+                    "-H 'Notion-Version: 2022-06-28' https://api.notion.com/v1/users/me"
+                ),
+            )
+        ]
+
+    def sign_in_snippet(
+        self, client_id: str, redirect_uri: str, scopes: Iterable[str]
+    ) -> str:
+        scope_str = "%20".join(sorted(scopes))
+        href = (
+            f"{self.authorize_endpoint}?client_id={client_id}&redirect_uri={redirect_uri}"
+            f"&response_type=code&owner=user&scope={scope_str}"
+        )
+        return textwrap.dedent(
+            """
+            <a href="{href}">
+              <button style="padding:10px 16px;background:#1f1f1f;color:#fff;border:none;border-radius:4px;">
+                Sign in with Notion
+              </button>
+            </a>
+            """
+        ).strip().format(href=href)
+
+    def menu_actions(self) -> List[ProviderAction]:
+        def _http(ctx: ProviderContext):
+            return ctx.http_client or requests
+
+        def search_workspace(ctx: ProviderContext) -> None:
+            http = _http(ctx)
+            response = http.post(
+                "https://api.notion.com/v1/search",
+                headers=_notion_headers(ctx.access_token, content_type="application/json"),
+                json={"page_size": 5},
+                timeout=10,
+            )
+            if response.status_code != 200:
+                ctx.echo("⚠️ Unable to search workspace. Ensure 'read:content' is granted.")
+                return
+            results = response.json().get("results", [])
+            if not results:
+                ctx.echo("ℹ️ No results returned. Share a page or database with the integration first.")
+                return
+            ctx.echo("\n📚 Search results:")
+            for item in results:
+                item_type = item.get("object")
+                title = "Unnamed"
+                if item_type == "page":
+                    properties = item.get("properties", {})
+                    for prop in properties.values():
+                        title = next(
+                            (
+                                rich_text.get("plain_text")
+                                for rich_text in prop.get("title", [])
+                                if rich_text.get("plain_text")
+                            ),
+                            title,
+                        )
+                        if title != "Unnamed":
+                            break
+                ctx.echo(f"  • {item_type}: {title}")
+
+        def list_users(ctx: ProviderContext) -> None:
+            http = _http(ctx)
+            response = http.get(
+                "https://api.notion.com/v1/users",
+                headers=_notion_headers(ctx.access_token),
+                params={"page_size": 5},
+                timeout=10,
+            )
+            if response.status_code != 200:
+                ctx.echo("⚠️ Unable to list users. Add the 'read:user' scope and re-authenticate.")
+                return
+            data = response.json()
+            for user in data.get("results", [])[:5]:
+                ctx.echo(f"  • {user.get('name')} ({user.get('type')})")
+
+        def create_page_stub(ctx: ProviderContext) -> None:
+            ctx.echo(
+                "🧱 Use POST /v1/pages with 'insert:content' and a parent database or page to create content."
+            )
+
+        return [
+            ProviderAction(
+                key="notion_search",
+                label="Notion: search workspace",
+                handler=search_workspace,
+                requires_any_scopes=["read:content"],
+                missing_scope_message="⚠️ Add 'read:content' to search pages and databases.",
+            ),
+            ProviderAction(
+                key="notion_list_users",
+                label="Notion: list users",
+                handler=list_users,
+                requires_any_scopes=["read:user"],
+                missing_scope_message="⚠️ Grant the 'read:user' scope to browse workspace members.",
+            ),
+            ProviderAction(
+                key="notion_create_page_stub",
+                label="Notion: page creation tips",
+                handler=create_page_stub,
+                requires_any_scopes=["insert:content"],
+                missing_scope_message="⚠️ Add 'insert:content' to create new Notion pages via API.",
+            ),
+        ]
+
+    def welcome_text(self, redirect_uri: str) -> str:
+        return textwrap.dedent(
+            """
+            👋 Welcome to the Notion OAuth wizard!
+            Bring an existing internal integration or let us show you how to create one.
+            """
+        ).strip()
+
+    def manual_entry_instructions(self) -> str:
+        return textwrap.dedent(
+            """
+            ✍️ Paste the Client ID and Client Secret from your Notion integration settings.
+            Manage integrations at https://www.notion.so/my-integrations.
+            """
+        ).strip()
+
+    def app_creation_instructions(self, redirect_uri: str) -> str:
+        return textwrap.dedent(
+            f"""
+            🛠️ Create an internal integration at https://www.notion.so/my-integrations.
+            1. Click "+ New integration" and give it a name.
+            2. Add the redirect URI {redirect_uri} under OAuth 2.0 settings.
+            3. Choose scopes such as read:content, insert:content, and read:user as needed.
+            Save and copy the Client ID and Secret to continue.
+            """
+        ).strip()
+
+    def load_credentials_from_file(self, path: str) -> tuple[str, str]:
+        with open(path) as fh:
+            data = json.load(fh)
+        client_id = data.get("client_id") or data.get("notion_client_id")
+        client_secret = data.get("client_secret") or data.get("notion_client_secret")
+        if not client_id or not client_secret:
+            raise ValueError(
+                "Notion credential JSON must include 'client_id' and 'client_secret'."
+            )
+        return client_id, client_secret
+
+    def validate_client_id(self, client_id: str) -> bool:
+        return bool(re.fullmatch(r"[0-9a-f]{32}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", client_id))
+
+    def validate_client_secret(self, client_secret: str) -> bool:
+        return bool(client_secret) and len(client_secret) >= 32
+
+
+provider = NotionProvider()

--- a/providers/slack.py
+++ b/providers/slack.py
@@ -1,0 +1,352 @@
+from __future__ import annotations
+
+import json
+import re
+import textwrap
+from typing import Dict, Iterable, List, Optional
+
+import requests
+
+from providers.base import EndpointInfo, ProviderAction, ProviderContext
+
+
+def _auth_headers(token: str) -> Dict[str, str]:
+    return {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json;charset=utf-8",
+    }
+
+
+class SlackProvider:
+    id = "slack"
+    name = "Slack"
+    authorize_endpoint = "https://slack.com/oauth/v2/authorize"
+    token_endpoint = "https://slack.com/api/oauth.v2.access"
+    userinfo_endpoint = "https://slack.com/api/users.profile.get"
+    tokeninfo_endpoint: Optional[str] = None
+    token_request_headers: Dict[str, str] = {
+        "Content-Type": "application/x-www-form-urlencoded",
+    }
+
+    def __init__(self) -> None:
+        self.base_scopes = ["users:read"]
+        self.scope_groups: Dict[str, Dict[str, List[str]]] = {
+            "Workspace": {
+                "read": ["team:read"],
+                "write": ["team:write"],
+            },
+            "Users": {
+                "read": ["users:read", "users:read.email"],
+                "write": ["users.profile:write"],
+            },
+            "Channels": {
+                "read": ["channels:read", "groups:read", "conversations:read"],
+                "write": ["channels:manage", "chat:write", "chat:write.public"],
+            },
+        }
+        self.discovery_metadata = {
+            "Workspace": {
+                "type": "slack_web_api",
+                "base_url": "https://slack.com/api",
+                "method_map": [
+                    {
+                        "path": "/team.info",
+                        "httpMethod": "GET",
+                        "description": "Get information about the current workspace.",
+                        "scopes": ["team:read"],
+                    },
+                    {
+                        "path": "/apps.connections.open",
+                        "httpMethod": "POST",
+                        "description": "Open an app-level websocket connection.",
+                        "scopes": ["team:write"],
+                    },
+                ],
+                "docs_url": "https://api.slack.com/methods/team.info",
+            },
+            "Users": {
+                "type": "slack_web_api",
+                "base_url": "https://slack.com/api",
+                "method_map": [
+                    {
+                        "path": "/users.profile.get",
+                        "httpMethod": "GET",
+                        "description": "Fetch a user's profile, including email when permitted.",
+                        "scopes": ["users:read", "users:read.email"],
+                    },
+                    {
+                        "path": "/users.list",
+                        "httpMethod": "GET",
+                        "description": "List users in the workspace.",
+                        "scopes": ["users:read"],
+                    },
+                    {
+                        "path": "/users.profile.set",
+                        "httpMethod": "POST",
+                        "description": "Update profile fields for the authed user.",
+                        "scopes": ["users.profile:write"],
+                    },
+                ],
+                "docs_url": "https://api.slack.com/methods/users.profile.get",
+            },
+            "Channels": {
+                "type": "slack_web_api",
+                "base_url": "https://slack.com/api",
+                "method_map": [
+                    {
+                        "path": "/conversations.list",
+                        "httpMethod": "GET",
+                        "description": "List public and private channels.",
+                        "scopes": ["conversations:read", "channels:read"],
+                    },
+                    {
+                        "path": "/chat.postMessage",
+                        "httpMethod": "POST",
+                        "description": "Send a message into a channel.",
+                        "scopes": ["chat:write", "chat:write.public"],
+                    },
+                ],
+                "docs_url": "https://api.slack.com/methods/conversations.list",
+            },
+        }
+
+    # Protocol implementation -------------------------------------------------
+    def build_authorization_url(
+        self, client_id: str, redirect_uri: str, scopes: Iterable[str]
+    ) -> str:
+        scope_str = "%20".join(sorted(scopes))
+        return (
+            f"{self.authorize_endpoint}?client_id={client_id}"
+            f"&redirect_uri={redirect_uri}&scope={scope_str}&user_scope={scope_str}"
+        )
+
+    def refresh_access_token(
+        self, client_id: str, client_secret: str, refresh_token: str
+    ) -> Optional[Dict]:
+        try:
+            response = requests.post(
+                self.token_endpoint,
+                data={
+                    "client_id": client_id,
+                    "client_secret": client_secret,
+                    "grant_type": "refresh_token",
+                    "refresh_token": refresh_token,
+                },
+                headers=self.token_request_headers,
+                timeout=15,
+            )
+        except Exception:
+            return None
+        if response.status_code == 200:
+            return response.json()
+        return None
+
+    def fetch_token_scopes(self, access_token: str) -> List[str]:
+        try:
+            response = requests.get(
+                "https://slack.com/api/apps.permissions.scopes.list",
+                headers=_auth_headers(access_token),
+                timeout=10,
+            )
+        except Exception:
+            return []
+        if response.status_code != 200:
+            return []
+        data = response.json()
+        if not data.get("ok"):
+            return []
+        scopes: List[str] = []
+        for section in data.get("scopes", {}).values():
+            if isinstance(section, dict):
+                for values in section.values():
+                    if isinstance(values, list):
+                        scopes.extend(values)
+            elif isinstance(section, list):
+                scopes.extend(section)
+        return sorted(set(scopes))
+
+    def fetch_user_email(self, access_token: str) -> Optional[str]:
+        http = requests
+        try:
+            auth_response = http.get(
+                "https://slack.com/api/auth.test",
+                headers=_auth_headers(access_token),
+                timeout=10,
+            )
+        except Exception:
+            return None
+        if auth_response.status_code != 200:
+            return None
+        payload = auth_response.json()
+        if not payload.get("ok"):
+            return None
+        user_id = payload.get("user_id")
+        if not user_id:
+            return None
+        try:
+            profile_response = http.get(
+                self.userinfo_endpoint,
+                headers=_auth_headers(access_token),
+                params={"user": user_id},
+                timeout=10,
+            )
+        except Exception:
+            return None
+        if profile_response.status_code != 200:
+            return None
+        profile_payload = profile_response.json()
+        if not profile_payload.get("ok"):
+            return None
+        profile = profile_payload.get("profile") or {}
+        return profile.get("email")
+
+    def userinfo_endpoints(self) -> List[EndpointInfo]:
+        return [
+            EndpointInfo(
+                service="Slack Web API",
+                method="GET",
+                url="https://slack.com/api/auth.test",
+                requires=["users:read"],
+                example="curl -H 'Authorization: Bearer $ACCESS_TOKEN' https://slack.com/api/auth.test",
+            ),
+            EndpointInfo(
+                service="Slack Web API",
+                method="GET",
+                url="https://slack.com/api/users.profile.get?user=$USER_ID",
+                requires=["users:read"],
+                example="curl -H 'Authorization: Bearer $ACCESS_TOKEN' 'https://slack.com/api/users.profile.get?user=$USER_ID'",
+            ),
+        ]
+
+    def sign_in_snippet(
+        self, client_id: str, redirect_uri: str, scopes: Iterable[str]
+    ) -> str:
+        scope_str = "%20".join(sorted(scopes))
+        href = (
+            f"{self.authorize_endpoint}?client_id={client_id}"
+            f"&redirect_uri={redirect_uri}&scope={scope_str}&user_scope={scope_str}"
+        )
+        return textwrap.dedent(
+            """
+            <a href="{href}">
+              <img src="https://a.slack-edge.com/80588/marketing/img/icons/icon_slack_hash_colored.png" alt="Sign in with Slack" style="height:40px;">
+            </a>
+            """
+        ).strip().format(href=href)
+
+    def menu_actions(self) -> List[ProviderAction]:
+        def _http(ctx: ProviderContext):
+            return ctx.http_client or requests
+
+        def show_workspace(ctx: ProviderContext) -> None:
+            http = _http(ctx)
+            response = http.get(
+                "https://slack.com/api/team.info",
+                headers=_auth_headers(ctx.access_token),
+                timeout=10,
+            )
+            data = response.json() if response.status_code == 200 else {"ok": False}
+            if not data.get("ok"):
+                ctx.echo("⚠️ Unable to fetch workspace info. Add 'team:read' scope and retry.")
+                return
+            team = data.get("team", {})
+            ctx.echo("\n🏢 Workspace info:")
+            ctx.echo(f"  • Name: {team.get('name')}")
+            ctx.echo(f"  • Domain: {team.get('domain')}.slack.com")
+
+        def list_channels(ctx: ProviderContext) -> None:
+            http = _http(ctx)
+            response = http.get(
+                "https://slack.com/api/conversations.list",
+                headers=_auth_headers(ctx.access_token),
+                params={"limit": 5},
+                timeout=10,
+            )
+            data = response.json() if response.status_code == 200 else {"ok": False}
+            if not data.get("ok"):
+                ctx.echo(
+                    "⚠️ Unable to list channels. Ensure 'conversations:read' or 'channels:read' scope is granted."
+                )
+                return
+            channels = data.get("channels", [])
+            if not channels:
+                ctx.echo("ℹ️ No channels returned.")
+                return
+            ctx.echo("\n#️⃣ Sample channels:")
+            for channel in channels:
+                ctx.echo(f"  • #{channel.get('name')} (id={channel.get('id')})")
+
+        def post_message_stub(ctx: ProviderContext) -> None:
+            ctx.echo(
+                "✉️ Use chat.postMessage with 'chat:write' scope to send messages."
+                " Provide a channel ID when running tests outside the wizard."
+            )
+
+        return [
+            ProviderAction(
+                key="slack_workspace_info",
+                label="Slack: show workspace info",
+                handler=show_workspace,
+                requires_any_scopes=["team:read"],
+                missing_scope_message="⚠️ Slack workspace scope missing. Add 'team:read'.",
+            ),
+            ProviderAction(
+                key="slack_list_channels",
+                label="Slack: list channels",
+                handler=list_channels,
+                requires_any_scopes=["conversations:read", "channels:read"],
+                missing_scope_message="⚠️ Grant 'conversations:read' or 'channels:read' to list channels.",
+            ),
+            ProviderAction(
+                key="slack_post_message",
+                label="Slack: how to post a message",
+                handler=post_message_stub,
+                requires_any_scopes=["chat:write"],
+                missing_scope_message="⚠️ Add 'chat:write' to send messages via the API.",
+            ),
+        ]
+
+    def welcome_text(self, redirect_uri: str) -> str:
+        return textwrap.dedent(
+            """
+            👋 Welcome to the Slack OAuth wizard!
+            We'll help you reuse an existing Slack app or walk you through creating a new one.
+            """
+        ).strip()
+
+    def manual_entry_instructions(self) -> str:
+        return textwrap.dedent(
+            """
+            ✍️ Paste your Slack App's Client ID and Client Secret below.
+            Manage your apps at https://api.slack.com/apps.
+            """
+        ).strip()
+
+    def app_creation_instructions(self, redirect_uri: str) -> str:
+        return textwrap.dedent(
+            f"""
+            🛠️ Create a Slack app at https://api.slack.com/apps.
+            1. Choose "Create New App" → "From scratch".
+            2. Add OAuth scopes under "OAuth & Permissions" (start with users:read, team:read).
+            3. Add the Redirect URL: {redirect_uri}
+            Save changes then copy the Client ID and Secret from "Basic Information".
+            """
+        ).strip()
+
+    def load_credentials_from_file(self, path: str) -> tuple[str, str]:
+        with open(path) as fh:
+            data = json.load(fh)
+        client_id = data.get("client_id")
+        client_secret = data.get("client_secret")
+        if not client_id or not client_secret:
+            raise ValueError("Slack JSON must contain 'client_id' and 'client_secret'.")
+        return client_id, client_secret
+
+    def validate_client_id(self, client_id: str) -> bool:
+        return bool(re.fullmatch(r"\d+\.\d+", client_id))
+
+    def validate_client_secret(self, client_secret: str) -> bool:
+        return bool(re.fullmatch(r"[A-Za-z0-9]{20,}", client_secret))
+
+
+provider = SlackProvider()

--- a/providers/trello.py
+++ b/providers/trello.py
@@ -1,0 +1,306 @@
+from __future__ import annotations
+
+import json
+import re
+import textwrap
+from typing import Dict, Iterable, List, Optional
+
+import requests
+
+from providers.base import EndpointInfo, ProviderAction, ProviderContext
+
+
+def _trello_headers(token: str) -> Dict[str, str]:
+    return {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+    }
+
+
+class TrelloProvider:
+    id = "trello"
+    name = "Trello"
+    authorize_endpoint = "https://trello.com/1/authorize"
+    token_endpoint = "https://api.trello.com/1/oauth2/token"
+    userinfo_endpoint = "https://api.trello.com/1/members/me"
+    tokeninfo_endpoint: Optional[str] = None
+    token_request_headers: Dict[str, str] = {
+        "Content-Type": "application/x-www-form-urlencoded",
+    }
+
+    def __init__(self) -> None:
+        self.base_scopes = ["read"]
+        self.scope_groups: Dict[str, Dict[str, List[str]]] = {
+            "Boards": {"read": ["read"], "write": ["write"]},
+            "Cards": {"read": ["read"], "write": ["write"]},
+            "Account": {"read": ["account"], "write": []},
+        }
+        self.discovery_metadata = {
+            "Boards": {
+                "type": "trello_catalog",
+                "base_url": "https://api.trello.com/1",
+                "method_map": [
+                    {
+                        "path": "/members/me/boards",
+                        "httpMethod": "GET",
+                        "description": "List boards accessible to the authorized user.",
+                        "scopes": ["read"],
+                    },
+                    {
+                        "path": "/boards/{board_id}/lists",
+                        "httpMethod": "GET",
+                        "description": "List lists on a board.",
+                        "scopes": ["read"],
+                    },
+                    {
+                        "path": "/boards",
+                        "httpMethod": "POST",
+                        "description": "Create a new board.",
+                        "scopes": ["write"],
+                    },
+                ],
+                "docs_url": "https://developer.atlassian.com/cloud/trello/rest/api-group-boards/",
+            },
+            "Cards": {
+                "type": "trello_catalog",
+                "base_url": "https://api.trello.com/1",
+                "method_map": [
+                    {
+                        "path": "/cards",
+                        "httpMethod": "POST",
+                        "description": "Create a card on a list.",
+                        "scopes": ["write"],
+                    },
+                    {
+                        "path": "/cards/{card_id}",
+                        "httpMethod": "GET",
+                        "description": "Retrieve a card.",
+                        "scopes": ["read"],
+                    },
+                ],
+                "docs_url": "https://developer.atlassian.com/cloud/trello/rest/api-group-cards/",
+            },
+            "Account": {
+                "type": "trello_catalog",
+                "base_url": "https://api.trello.com/1",
+                "method_map": [
+                    {
+                        "path": "/members/me",
+                        "httpMethod": "GET",
+                        "description": "Fetch account profile information.",
+                        "scopes": ["read", "account"],
+                    },
+                ],
+                "docs_url": "https://developer.atlassian.com/cloud/trello/rest/api-group-members/",
+            },
+        }
+
+    # Protocol implementation -------------------------------------------------
+    def build_authorization_url(
+        self, client_id: str, redirect_uri: str, scopes: Iterable[str]
+    ) -> str:
+        scope_str = ",".join(sorted(scopes))
+        return (
+            f"{self.authorize_endpoint}?response_type=code"
+            f"&client_id={client_id}"
+            f"&scope={scope_str}"
+            f"&redirect_uri={redirect_uri}"
+            f"&expiration=30days"
+            f"&name=OAuth%20Wizard"
+        )
+
+    def refresh_access_token(
+        self, client_id: str, client_secret: str, refresh_token: str
+    ) -> Optional[Dict]:
+        try:
+            response = requests.post(
+                self.token_endpoint,
+                data={
+                    "grant_type": "refresh_token",
+                    "client_id": client_id,
+                    "client_secret": client_secret,
+                    "refresh_token": refresh_token,
+                },
+                headers=self.token_request_headers,
+                timeout=15,
+            )
+        except Exception:
+            return None
+        if response.status_code == 200:
+            return response.json()
+        return None
+
+    def fetch_token_scopes(self, access_token: str) -> List[str]:
+        try:
+            response = requests.get(
+                "https://api.trello.com/1/members/me",
+                headers=_trello_headers(access_token),
+                params={"fields": "id,username,fullName"},
+                timeout=10,
+            )
+        except Exception:
+            return []
+        if response.status_code != 200:
+            return []
+        data = response.json()
+        scopes = data.get("grantedScopes") or []
+        if isinstance(scopes, list):
+            return sorted(set(scopes))
+        if isinstance(scopes, str):
+            return sorted({scope.strip() for scope in scopes.split(" ") if scope.strip()})
+        return []
+
+    def fetch_user_email(self, access_token: str) -> Optional[str]:
+        try:
+            response = requests.get(
+                self.userinfo_endpoint,
+                headers=_trello_headers(access_token),
+                params={"fields": "username,fullName,email"},
+                timeout=10,
+            )
+        except Exception:
+            return None
+        if response.status_code != 200:
+            return None
+        data = response.json()
+        return data.get("email")
+
+    def userinfo_endpoints(self) -> List[EndpointInfo]:
+        return [
+            EndpointInfo(
+                service="Trello API",
+                method="GET",
+                url="https://api.trello.com/1/members/me",
+                requires=["read"],
+                example="curl -H 'Authorization: Bearer $ACCESS_TOKEN' https://api.trello.com/1/members/me",
+            )
+        ]
+
+    def sign_in_snippet(
+        self, client_id: str, redirect_uri: str, scopes: Iterable[str]
+    ) -> str:
+        scope_str = ",".join(sorted(scopes))
+        href = (
+            f"{self.authorize_endpoint}?response_type=code&client_id={client_id}"
+            f"&scope={scope_str}&redirect_uri={redirect_uri}&expiration=30days&name=OAuth%20Wizard"
+        )
+        return textwrap.dedent(
+            """
+            <a href="{href}">
+              <button style="padding:10px 16px;background:#026aa7;color:#fff;border:none;border-radius:4px;">
+                Sign in with Trello
+              </button>
+            </a>
+            """
+        ).strip().format(href=href)
+
+    def menu_actions(self) -> List[ProviderAction]:
+        def _http(ctx: ProviderContext):
+            return ctx.http_client or requests
+
+        def list_boards(ctx: ProviderContext) -> None:
+            http = _http(ctx)
+            response = http.get(
+                "https://api.trello.com/1/members/me/boards",
+                headers=_trello_headers(ctx.access_token),
+                params={"limit": 5, "fields": "name,url"},
+                timeout=10,
+            )
+            if response.status_code != 200:
+                ctx.echo("⚠️ Unable to list boards. Ensure the 'read' scope is granted.")
+                return
+            boards = response.json()
+            if not boards:
+                ctx.echo("ℹ️ No boards returned for this account.")
+                return
+            ctx.echo("\n📋 Boards:")
+            for board in boards:
+                ctx.echo(f"  • {board.get('name')} → {board.get('url')}")
+
+        def show_profile(ctx: ProviderContext) -> None:
+            http = _http(ctx)
+            response = http.get(
+                self.userinfo_endpoint,
+                headers=_trello_headers(ctx.access_token),
+                params={"fields": "username,fullName,email"},
+                timeout=10,
+            )
+            if response.status_code != 200:
+                ctx.echo("⚠️ Unable to fetch member profile. Add the 'account' scope for email access.")
+                return
+            ctx.echo(json.dumps(response.json(), indent=2))
+
+        def card_creation_stub(ctx: ProviderContext) -> None:
+            ctx.echo(
+                "🗒️ Ready to create cards? Call POST /1/cards with 'write' scope and list id."
+            )
+
+        return [
+            ProviderAction(
+                key="trello_boards",
+                label="Trello: list boards",
+                handler=list_boards,
+                requires_any_scopes=["read"],
+                missing_scope_message="⚠️ Add the 'read' scope to access boards.",
+            ),
+            ProviderAction(
+                key="trello_profile",
+                label="Trello: show member profile JSON",
+                handler=show_profile,
+                requires_any_scopes=["account", "read"],
+                missing_scope_message="⚠️ Add 'account' scope to fetch profile details including email.",
+            ),
+            ProviderAction(
+                key="trello_cards_stub",
+                label="Trello: card creation tips",
+                handler=card_creation_stub,
+                requires_any_scopes=["write"],
+                missing_scope_message="⚠️ Grant the 'write' scope to create cards via the API.",
+            ),
+        ]
+
+    def welcome_text(self, redirect_uri: str) -> str:
+        return textwrap.dedent(
+            """
+            👋 Welcome to the Trello OAuth wizard!
+            We'll reuse an existing Trello OAuth 2.0 client or help you grab the keys you need.
+            """
+        ).strip()
+
+    def manual_entry_instructions(self) -> str:
+        return textwrap.dedent(
+            """
+            ✍️ Paste your Trello OAuth client ID (API key) and client secret below.
+            Manage credentials at https://trello.com/app-key.
+            """
+        ).strip()
+
+    def app_creation_instructions(self, redirect_uri: str) -> str:
+        return textwrap.dedent(
+            f"""
+            🛠️ Visit https://trello.com/app-key and click "Token" to enable OAuth 2.0.
+            Add the redirect URL {redirect_uri} under OAuth 2 redirect URLs.
+            Request scopes like read, write, and account depending on your needs.
+            Copy the API key (Client ID) and generate a new secret for the wizard.
+            """
+        ).strip()
+
+    def load_credentials_from_file(self, path: str) -> tuple[str, str]:
+        with open(path) as fh:
+            data = json.load(fh)
+        client_id = data.get("client_id") or data.get("api_key")
+        client_secret = data.get("client_secret") or data.get("secret")
+        if not client_id or not client_secret:
+            raise ValueError(
+                "Trello credential JSON must include 'client_id' and 'client_secret'."
+            )
+        return client_id, client_secret
+
+    def validate_client_id(self, client_id: str) -> bool:
+        return bool(re.fullmatch(r"[0-9a-f]{32}", client_id))
+
+    def validate_client_secret(self, client_secret: str) -> bool:
+        return bool(client_secret) and len(client_secret) >= 32
+
+
+provider = TrelloProvider()

--- a/scopes.py
+++ b/scopes.py
@@ -71,6 +71,36 @@ def _google_discovery_handler(config: Dict) -> List[Dict]:
 register_discovery_handler("google_discovery", _google_discovery_handler)
 
 
+def _method_catalog_handler(config: Dict) -> List[Dict]:
+    methods: List[Dict] = []
+    base_url = config.get("base_url", "")
+    for entry in config.get("method_map", []):
+        if not isinstance(entry, dict):
+            continue
+        path = entry.get("path") or entry.get("endpoint") or entry.get("name")
+        if not path:
+            continue
+        http_method = entry.get("httpMethod") or entry.get("http_method") or entry.get("method") or "GET"
+        description = entry.get("description", "")
+        scopes = entry.get("scopes", [])
+        methods.append(
+            {
+                "httpMethod": str(http_method).upper(),
+                "path": path,
+                "description": description,
+                "scopes": scopes if isinstance(scopes, list) else [str(scopes)],
+                "baseUrl": base_url,
+            }
+        )
+    return methods
+
+
+register_discovery_handler("basecamp_catalog", _method_catalog_handler)
+register_discovery_handler("slack_web_api", _method_catalog_handler)
+register_discovery_handler("trello_catalog", _method_catalog_handler)
+register_discovery_handler("notion_catalog", _method_catalog_handler)
+
+
 def discover_methods_for_service(provider: OAuthProvider, service: str) -> List[Dict]:
     meta = provider.discovery_metadata.get(service)
     if not meta:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import pytest
 from typer.testing import CliRunner
 
 from cli import main as cli_main
@@ -129,3 +130,32 @@ def test_test_endpoint_command_bootstraps_and_runs(monkeypatch):
             "browser-opener",
         )
     ]
+
+
+@pytest.mark.parametrize(
+    "provider_id",
+    ["google", "github", "basecamp", "slack", "trello", "notion"],
+)
+def test_choose_provider_by_id_returns_registered_provider(provider_id):
+    provider = cli_main._choose_provider(provider_id)
+    assert provider.id == provider_id
+
+
+@pytest.mark.parametrize(
+    "provider_id",
+    ["github", "basecamp", "slack", "trello", "notion"],
+)
+def test_render_menu_includes_provider_actions(provider_id):
+    provider = cli_main._choose_provider(provider_id)
+    menu = cli_main._render_menu(provider, provider.base_scopes)
+    assert any(entry[0] == "provider_action" for entry in menu)
+
+
+@pytest.mark.parametrize(
+    "provider_id",
+    ["basecamp", "slack", "trello", "notion"],
+)
+def test_discovered_services_present_for_new_providers(provider_id):
+    provider = cli_main._choose_provider(provider_id)
+    discovered = cli_main._list_discovered_services(provider)
+    assert discovered, f"Expected discovery metadata for {provider_id}"


### PR DESCRIPTION
## Summary
- implement Basecamp, Slack, Trello, and Notion OAuth providers with scope catalogs, discovery metadata, and provider-specific menu actions
- add reusable discovery handler registrations for static API catalogs and register the new providers in the factory
- extend CLI tests to cover provider selection, menu integration, and discovery availability for the new providers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68daf02f5bac83288463f51c31242ad5